### PR TITLE
Manifest V3に対応

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,14 @@
 {
 	"name": "さくらのコントロールパネルリンク",
 	"version": "0.1.4",
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"description": "さくらインターネットの各種サービスコントロールパネルリンク集",
 	"icons": {
 		"16": "./icons/icon16.png",
 		"48": "./icons/icon48.png",
 		"128": "./icons/icon128.png"
 	},
-	"browser_action": {
+	"action": {
 		"default_icon": {
 			"19": "./icons/icon19.png",
 			"38": "./icons/icon38.png"

--- a/manifest.json
+++ b/manifest.json
@@ -1,20 +1,19 @@
 {
-  "name": "さくらのコントロールパネルリンク",
-  "version": "0.1.4",
-  "manifest_version": 2,
-  "description": "さくらインターネットの各種サービスコントロールパネルリンク集",
-  "icons": {
-      "16": "./icons/icon16.png",
-      "48": "./icons/icon48.png",
-      "128": "./icons/icon128.png"
-
-  },
-  "browser_action": {
-      "default_icon": {
-          "19": "./icons/icon19.png",
-          "38": "./icons/icon38.png"
-      },
-      "default_title": "Sakura Links",
-      "default_popup": "./popup.html"
-  }
+	"name": "さくらのコントロールパネルリンク",
+	"version": "0.1.4",
+	"manifest_version": 2,
+	"description": "さくらインターネットの各種サービスコントロールパネルリンク集",
+	"icons": {
+		"16": "./icons/icon16.png",
+		"48": "./icons/icon48.png",
+		"128": "./icons/icon128.png"
+	},
+	"browser_action": {
+		"default_icon": {
+			"19": "./icons/icon19.png",
+			"38": "./icons/icon38.png"
+		},
+		"default_title": "Sakura Links",
+		"default_popup": "./popup.html"
+	}
 }


### PR DESCRIPTION
## 背景

段階的にManifest V2が廃止されています。
https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline

いつのまにかChromeウェブストアからインストールできなくなってしまいました 😢
![image](https://github.com/user-attachments/assets/b2a419aa-31f6-4953-b022-73d48f13ea92)

今後も使いたいのでManifest V3に対応しました。

## 変更内容

- manifest.jsonをV3に対応
- ばらつきのあったインデントも統一

<ins>※ Chrome拡張機能の開発経験ないので間違ってるところあればご指摘ください 🙏 </ins>