### PR TITLE
シークレットモードのままリンクが開けるようにした

### DIFF
--- a/script/popup.js
+++ b/script/popup.js
@@ -106,8 +106,9 @@ function main() {
         li.addEventListener('mouseleave', function (event) {
             event.target.classList.remove('item--hover');
         });
-        li.addEventListener('click', function () {
-            chrome.tabs.create({active: true, url: link.href})
+        li.addEventListener('click', function (event) {
+            event.preventDefault();
+            chrome.tabs.create({active: true, url: link.href});
         })
 
         li.innerHTML = [

--- a/script/popup.js
+++ b/script/popup.js
@@ -106,9 +106,12 @@ function main() {
         li.addEventListener('mouseleave', function (event) {
             event.target.classList.remove('item--hover');
         });
+        li.addEventListener('click', function () {
+            chrome.tabs.create({active: true, url: link.href})
+        })
 
         li.innerHTML = [
-            '<a class="item__link" href="' + link.href + '" target="_blank">',
+            '<a class="item__link" href="' + link.href + '">',
             '<img class="link__image" src="' + link.image + '">',
             '<span class="link__title' + (needsCompress ? ' link__title--compress' : '') + '">' + link.label + '</span>',
             '</a>'


### PR DESCRIPTION
## 背景

[拡張機能の設定に行くとシークレットモードでも使うようにできる](https://github.com/user-attachments/assets/594e581b-606b-4e39-b948-1176e4f79e7c)のですが、実際にシークレットモードからリンクをクリックすると通常モードに戻ってタブが開いてしまいます。

https://github.com/user-attachments/assets/139e6069-844b-40d3-92c7-85f6ae493bc4

シークレットモードのまま使いたいときに不便でしたので改善してみました。


## 変更内容

- chrome.tabs APIを用いてタブを開くようにしました